### PR TITLE
Proposed changes to support some basic Azure provisioning use cases (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ end
 ## Currently untested/Known issues
  * Windows/WinRM bootstrap
  * Load-balanced sets
+ * Availability sets/Fault domains
+ * Cloud Service autoscaling
+ * Endpoint monitoring
  * Additional disk volumes
  * Affinity groups
  * Direct server return IP addresses

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # chef-provisioning-azure
 
-Implementation of an Azure driver that relies on the Azure SDK. 
-
+Implementation of an Azure driver that relies on the Azure SDK for Ruby. 
 
 ## What does it do?
 
@@ -17,8 +16,9 @@ machine_options = {
     :bootstrap_options => {
       :cloud_service_name => 'chefprovisioning',
       :storage_account_name => 'chefprovisioning',
-      #:vm_size => "A7"
-      :location => 'West US'
+      :vm_size => "Standard_D1"
+      :location => 'West US',
+      :tcp_endpoints => '80:80'
     },
     #:image_id => 'foobar'
     # Until SSH keys are supported (soon)
@@ -30,8 +30,26 @@ machine 'toad' do
 end
 ```
  
-That's it. No images, nothing else. Do not expect much just yet. Currently you have to specify the 
-password you want the initial user to have in your recipe. No, this will not be for very long. 
+## Supported Features
+ * Automatic creation and teardown of Cloud Services
+ * Public (OS) images and captured User (VM) images 
+ * Up to date (February 2015) VM sizes including 'D', 'DS' and 'G' sizes.
+ * Custom TCP/UDP endpoints per VM role
+ * Linux VMs, SSH external bootstrap via public port
+
+## Currently untested/Known issues
+ * Windows/WinRM bootstrap
+ * Load-balanced sets
+ * Additional disk volumes
+ * Affinity groups
+ * Direct server return IP addresses
+ * Reserved/Static IP addresses
+ * Virtual network allocation
+ * Bootstrap via internal (private) addresses
+ * CDN/TrafficManager
+ * Non-IaaS Azure services (e.g CDN/TrafficManager Service Bus, Azure SQL Database, Media Services, Redis Cache)
+
+Currently you have to specify the password you want the initial user to have in your recipe. No, this will not be for very long.
 
 ### Setting your credentials
 


### PR DESCRIPTION
__Health warning:__
Sorry for the length of the comments here - this proposed merge will not work as desired without bundling my associated fork of https://github.com/stuartpreston/azure-sdk-for-ruby (master).  The origin SDK has not had a release since 0.6.4 (May 2014) and the number of outstanding issues/pull requests as a result are growing, hence the need to have a fork until the project can get back on track.  I don't know how the project feels about bundling from source, but I guess this could be achieved by adding my fork to the chef-provisioning-azure [?] gemfile.  I guess source-bundling would protect us from other tools that take a dependency on Azure currently (luckily/unluckily I see knife-azure doesn't...)

For my testing, I have been doing a manual build of my forked Azure gem before testing with my local chef-provisioning-azure code in the following manner:

```
gem uninstall azure
gem build azure.gemspec
gem install azure-0.6.4.gem
```

In that fork, I have added the following functionality:
* Updated VM sizes
* Support for User-captured images as well as the Public images
* Modifications so that User-captured images are allocated a public endpoint on the cloud service
* Other general fixes and modifications
 
Here's my test recipe that exercises the new bits.  Note I haven't changed any resources just yet.

```ruby
require 'chef/provisioning/azure_driver'
with_driver 'azure'

# Create a Standard_D1 sized VM from an OS image, with two endpoints listening on
# pendricacloud01.cloudapp.net:8080 and pendricacloud01.cloudapp.net:8443
machine 'pendev01app01' do
  machine_options :bootstrap_options => {
      :cloud_service_name => 'pendricacloud01',
      :storage_account_name => 'pendricastore01',
      :vm_size => 'Standard_D1',
      :location => 'North Europe',
      :tcp_endpoints => '80:8080,443:8443'
    },
    :password => 'P2ssw0rd',
    :image_id => 'b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_1-LTS-amd64-server-20140927-en-us-30GB'
end

# Create a Standard_D1 sized VM from a User/captured image, with two endpoints listening on
# pendricacloud01.cloudapp.net:8081 and pendricacloud01.cloudapp.net:9443
machine 'pendev01app02' do
  machine_options :bootstrap_options => { 
      :cloud_service_name => 'pendricacloud01',
      :storage_account_name => 'pendricastore01',
      :vm_size => 'Standard_D1',
      :location => 'North Europe',
      :tcp_endpoints => '80:8081,443:9443'
    },
    :password => 'P2ssw0rd',
    :image_id => 'pendev01app01-20150223-402981'
end
```

This example recipe would
 * create a Cloud Service
 * boot the two machines (one from the Public images and one which is a User image)
 * the machines are bootstrapped using their public SSH ports (the SSH ports do not need to be listed in the recipe - they are added automatically by the Azure SDK)
 * the storage account in this case must already exist because it has the User image within it.

### Result

![spvm2015_cloudapp_net](https://cloud.githubusercontent.com/assets/6384654/6362043/a332a246-bc80-11e4-8c69-5a5a6f58b09c.png)

![spvm2015_cloudapp_net 2](https://cloud.githubusercontent.com/assets/6384654/6362356/281414c4-bc84-11e4-942e-d6ffa1cc8b99.png)

![spvm2015_cloudapp_net 3](https://cloud.githubusercontent.com/assets/6384654/6362379/74f157ac-bc84-11e4-86e3-910aaae3dcb4.png)

The changes associated with this merge are merely a tidy up of the shared parameters as recommended in the comments on #7 and to fix an issue where you couldn't create a VM role if an empty Cloud Service already existed #8 - oh, and I updated the Readme with the bits that should now work...

Associated issues potentially fixed #9 #8 #5 