### PR TITLE
Repointing Gemfile to publicly released fork of Azure SDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gemfile
 gemspec
 
-gem 'azure', github: 'stuartpreston/azure-sdk-for-ruby'
+gem 'stuartpreston-azure-sdk-for-ruby', '~> 0.6.5'

--- a/chef-provisioning-azure.gemspec
+++ b/chef-provisioning-azure.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef'
   s.add_dependency 'chef-provisioning', '~> 0.9'
-  s.add_dependency 'azure'
+  s.add_dependency 'stuartpreston-azure-sdk-for-ruby', '0.6.5'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
As I have had to change the name of my forked Azure SDK, the Gemfile dep needs to be modified.
Associated with #5 