### PR TITLE
Adding support for .publishsettings file used for authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 gemfile
 gemspec
+
+gem 'azure', github: 'stuartpreston/azure-sdk-for-ruby'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gemfile
 gemspec
 
-gem 'stuartpreston-azure-sdk-for-ruby', '~> 0.6.6'
+gem 'stuartpreston-azure-sdk-for-ruby', '~> 0.6.7'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gemfile
 gemspec
 
-gem 'azure', github: 'stuartpreston/azure-sdk-for-ruby'
+gem 'stuartpreston-azure-sdk-for-ruby', '~> 0.6.5'

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ end
 ## Currently untested/Known issues
  * Windows/WinRM bootstrap
  * Load-balanced sets
+ * Availability sets/Fault domains
+ * Cloud Service autoscaling
+ * Endpoint monitoring
  * Additional disk volumes
  * Affinity groups
  * Direct server return IP addresses

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # chef-provisioning-azure
 
-Implementation of an Azure driver that relies on the Azure SDK. 
-
+Implementation of an Azure driver that relies on the Azure SDK for Ruby. 
 
 ## What does it do?
 
@@ -17,8 +16,9 @@ machine_options = {
     :bootstrap_options => {
       :cloud_service_name => 'chefprovisioning',
       :storage_account_name => 'chefprovisioning',
-      #:vm_size => "A7"
-      :location => 'West US'
+      :vm_size => "Standard_D1"
+      :location => 'West US',
+      :tcp_endpoints => '80:80'
     },
     #:image_id => 'foobar'
     # Until SSH keys are supported (soon)
@@ -30,8 +30,26 @@ machine 'toad' do
 end
 ```
  
-That's it. No images, nothing else. Do not expect much just yet. Currently you have to specify the 
-password you want the initial user to have in your recipe. No, this will not be for very long. 
+## Supported Features
+ * Automatic creation and teardown of Cloud Services
+ * Public (OS) images and captured User (VM) images 
+ * Up to date (February 2015) VM sizes including 'D', 'DS' and 'G' sizes.
+ * Custom TCP/UDP endpoints per VM role
+ * Linux VMs, SSH external bootstrap via public port
+
+## Currently untested/Known issues
+ * Windows/WinRM bootstrap
+ * Load-balanced sets
+ * Additional disk volumes
+ * Affinity groups
+ * Direct server return IP addresses
+ * Reserved/Static IP addresses
+ * Virtual network allocation
+ * Bootstrap via internal (private) addresses
+ * CDN/TrafficManager
+ * Non-IaaS Azure services (e.g CDN/TrafficManager Service Bus, Azure SQL Database, Media Services, Redis Cache)
+
+Currently you have to specify the password you want the initial user to have in your recipe. No, this will not be for very long.
 
 ### Setting your credentials
 

--- a/chef-provisioning-azure.gemspec
+++ b/chef-provisioning-azure.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef'
   s.add_dependency 'chef-provisioning', '~> 0.9'
-  s.add_dependency 'azure'
+  s.add_dependency 'stuartpreston-azure-sdk-for-ruby', '0.6.5'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/chef-provisioning-azure.gemspec
+++ b/chef-provisioning-azure.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef'
   s.add_dependency 'chef-provisioning', '~> 0.9'
-  s.add_dependency 'stuartpreston-azure-sdk-for-ruby', '~> 0.6.6'
+  s.add_dependency 'stuartpreston-azure-sdk-for-ruby', '~> 0.6.7'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes #16 by using v0.6.7 of the forked Azure SDK, which supports using .publishsettings and subscription id in places of the management_certificate parameter in ~/.azure/config