### PR TITLE
Adding ancillary resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .yardoc
 Gemfile.lock
 Gemfile.local
-.gem
+*.gem

--- a/docs/resources/work_in_progress.rb
+++ b/docs/resources/work_in_progress.rb
@@ -1,0 +1,52 @@
+require 'chef/provisioning/azure_driver'
+with_driver 'azure'
+
+# NOTE: THESE ARE ASPIRATIONAL RESOURCES, SUBJECT TO CHANGE
+# THEY ALSO DO NOT STORE A MANAGEDENTRY IN CHEF SERVER
+# USE ONLY TO CREATE UNMANAGED RESOURCES IN AZURE
+#
+# USE AT OWN RISK!!
+
+## Auxiliary resources
+
+azure_storage_account 'spteststorage41' do
+  action :create
+  options :location => 'West US',
+          :geo_replication_enabled => false
+end
+
+azure_cloud_service 'sptestcloud41' do
+  action :create
+  options :location => 'West US'
+end
+
+## PAAS resources
+
+# note: azure_sql_server does not accept being provided a name until APIv2 (RM)
+# Azure will autogenerate a name, we should store this I guess so it can be used
+# later on...
+azure_sql_server 'sptestsql41' do
+  action :create
+  options :location => 'West US',
+          :login => 'sqluser',
+          :password => 'P2ssw0rd',
+          :firewall_rules => [
+            {
+              :name => 'rule 1',
+              :start_ip_address => '10.0.0.1',
+              :end_ip_address => '10.0.0.2'
+            },
+            {
+              :name => 'rule 2',
+              :start_ip_address => '10.1.0.1',
+              :end_ip_address => '10.1.0.2'
+            }
+          ]
+end
+
+## NOT WORKING - DO NOT USE
+#azure_service_bus_queue 'sptestqueue01' do
+#  action :create
+#  namespace 'mynamespace'
+#  options :max_size_in_megabytes => 2048
+#end

--- a/lib/chef/provider/azure_cloud_service.rb
+++ b/lib/chef/provider/azure_cloud_service.rb
@@ -8,7 +8,7 @@ class Chef
         csms = Azure::CloudServiceManagementService.new
         csms.create_cloud_service(new_resource.name, new_resource.options)
         properties = csms.get_cloud_service_properties(new_resource.name)
-        Chef::Log.info("Properties of #{new_resource.name}: #{properties.inspect}")
+        Chef::Log.debug("Properties of #{new_resource.name}: #{properties.inspect}")
       end
 
       action :destroy do

--- a/lib/chef/provider/azure_cloud_service.rb
+++ b/lib/chef/provider/azure_cloud_service.rb
@@ -1,0 +1,21 @@
+require 'chef/provisioning/azure_driver/azure_provider'
+
+class Chef
+  class Provider
+    class AzureCloudService < Chef::Provisioning::AzureDriver::AzureProvider
+      action :create do
+        Chef::Log.info("Creating AzureCloudService: #{new_resource.name}")
+        csms = Azure::CloudServiceManagementService.new
+        csms.create_cloud_service(new_resource.name, new_resource.options)
+        properties = csms.get_cloud_service_properties(new_resource.name)
+        Chef::Log.info("Properties of #{new_resource.name}: #{properties.inspect}")
+      end
+
+      action :destroy do
+        Chef::Log.info("Destroying AzureCloudService: #{new_resource.name}")
+        csms = Azure::CloudServiceManagementService.new
+        csms.delete_cloud_service(new_resource.name)
+      end
+    end
+  end
+end

--- a/lib/chef/provider/azure_sql_server.rb
+++ b/lib/chef/provider/azure_sql_server.rb
@@ -1,0 +1,36 @@
+require 'chef/provisioning/azure_driver/azure_provider'
+
+class Chef
+  class Provider
+    class AzureSqlServer < Chef::Provisioning::AzureDriver::AzureProvider
+      action :create do
+        restore = Azure.config.management_endpoint
+        Azure.config.management_endpoint = azure_sql_management_endpoint
+        Chef::Log.info("Creating AzureSqlServer: #{new_resource.name}")
+        csql = Azure::SqlDatabaseManagementService.new
+        Chef::Log.info("#{new_resource.options.inspect}")
+        properties = csql.create_server("#{new_resource.options[:login]}", \
+                                        "#{new_resource.options[:password]}", \
+                                        "#{new_resource.options[:location]}")
+        server = properties.name
+
+        new_resource.options[:firewall_rules].each do | rule |
+          rule_name = URI::encode(rule[:name])
+          range = {
+            :start_ip_address => rule[:start_ip_address],
+            :end_ip_address => rule[:end_ip_address]
+          }
+          csql.set_sql_server_firewall_rule(server, rule_name, range)
+        end
+
+        Chef::Log.info("Properties of #{new_resource.name}: #{properties.inspect}")
+        Azure.config.management_endpoint = restore
+      end
+
+      action :destroy do
+        # not supported
+        fail "Destroy not yet implemented on Azure SQL Server using ASM."
+      end
+    end
+  end
+end

--- a/lib/chef/provider/azure_storage_account.rb
+++ b/lib/chef/provider/azure_storage_account.rb
@@ -1,0 +1,21 @@
+require 'chef/provisioning/azure_driver/azure_provider'
+
+class Chef
+  class Provider
+    class AzureStorageAccount < Chef::Provisioning::AzureDriver::AzureProvider
+      action :create do
+        Chef::Log.info("Creating AzureStorageAccount: #{new_resource.name}")
+        sms = Azure::StorageManagementService.new
+        sms.create_storage_account(new_resource.name, new_resource.options)
+        properties = sms.get_storage_account_properties(new_resource.name)
+        Chef::Log.info("Properties of #{new_resource.name}: #{properties.inspect}")
+      end
+
+      action :destroy do
+        Chef::Log.info("Destroying AzureStorageAccount: #{new_resource.name}")
+        sms = Azure::StorageManagementService.new
+        sms.delete_storage_account(new_resource.name)
+      end
+    end
+  end
+end

--- a/lib/chef/provider/azure_storage_account.rb
+++ b/lib/chef/provider/azure_storage_account.rb
@@ -8,7 +8,7 @@ class Chef
         sms = Azure::StorageManagementService.new
         sms.create_storage_account(new_resource.name, new_resource.options)
         properties = sms.get_storage_account_properties(new_resource.name)
-        Chef::Log.info("Properties of #{new_resource.name}: #{properties.inspect}")
+        Chef::Log.debug("Properties of #{new_resource.name}: #{properties.inspect}")
       end
 
       action :destroy do

--- a/lib/chef/provisioning/azure_driver/azure_provider.rb
+++ b/lib/chef/provisioning/azure_driver/azure_provider.rb
@@ -11,6 +11,10 @@ class Chef
 
         AzureResource = Chef::Provisioning::AzureDriver::AzureResource
 
+        def azure_sql_management_endpoint
+          'https://management.database.windows.net:8443'
+        end
+
         def action_handler
           @action_handler ||= Chef::Provisioning::ChefProviderActionHandler.new(self)
         end

--- a/lib/chef/provisioning/azure_driver/azure_provider.rb
+++ b/lib/chef/provisioning/azure_driver/azure_provider.rb
@@ -1,0 +1,29 @@
+require 'chef/provider/lwrp_base'
+require 'chef/provisioning/azure_driver/azure_resource'
+require 'chef/provisioning/chef_provider_action_handler'
+require 'azure'
+
+class Chef
+  module Provisioning
+    module AzureDriver
+      class AzureProvider < Chef::Provider::LWRPBase
+        use_inline_resources
+
+        AzureResource = Chef::Provisioning::AzureDriver::AzureResource
+
+        def action_handler
+          @action_handler ||= Chef::Provisioning::ChefProviderActionHandler.new(self)
+        end
+
+        # All these need to implement whyrun
+        def whyrun_supported?
+          true
+        end
+
+        def driver
+          new_resource.driver
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/provisioning/azure_driver/azure_resource.rb
+++ b/lib/chef/provisioning/azure_driver/azure_resource.rb
@@ -7,25 +7,30 @@ class Chef
       class AzureResource < Chef::Resource::LWRPBase
         def initialize(*args)
           super
-          @chef_environment = run_context.cheffish.current_environment
-          @chef_server = run_context.cheffish.current_chef_server
-          @driver = run_context.chef_provisioning.current_driver
+          if run_context
+            @chef_environment = run_context.cheffish.current_environment
+            @chef_server = run_context.cheffish.current_chef_server
+            @driver = run_context.chef_provisioning.current_driver
+          end
 
           config = run_context.chef_provisioning.config
           scheme, account_id = driver.split(':', 2)
 
           if account_id.nil? || account_id.empty?
             subscription = Subscriptions.default_subscription(config)
+            config = Cheffish::MergedConfig.new({ azure_subscriptions: subscription }, config)
             if !subscription
-              raise "Driver #{driver_url} did not specify a subscription ID, and no default subscription was found.  Have you downloaded the Azure CLI and used `azure account download` and `azure account import` to set up Azure?  Alternately, you can set azure_subscriptions to [ { subscription_id: '...', management_credentials: ... }] in your Chef configuration."
+              raise "Driver #{driver} did not specify a subscription ID, and no default subscription was found.  Have you downloaded the Azure CLI and used `azure account download` and `azure account import` to set up Azure?  Alternately, you can set azure_subscriptions to [ { subscription_id: '...', management_credentials: ... }] in your Chef configuration."
             end
+          else
+            subscription_id = account_id || subscription[:subscription_id]
+            subscription = Subscriptions.get_subscription(config, subscription_id)
           end
 
-          config = Cheffish::MergedConfig.new({ azure_subscriptions: subscription }, config)
-          scheme, subscription_id = driver.split(':', 2)
-          @subscription = Subscriptions.get_subscription(config, subscription_id)
           if !subscription
-            raise "Driver #{driver_url} has a subscription ID, but the system has no credentials configured for it!  If you have access to this subscription, you can use `azure account download` and `azure account import` in the Azure CLI to get the credentials, or set azure_subscriptions to [ { subscription_id: '...', management_credentials: ... }] in your Chef configuration."
+            raise "Driver #{driver} has a subscription ID (#{subscription_id}), but the system has no credentials configured for it!  If you have access to this subscription, you can use `azure account download` and `azure account import` in the Azure CLI to get the credentials, or set azure_subscriptions to [ { subscription_id: '...', management_credentials: ... }] in your Chef configuration."
+          else
+            Chef::Log.debug("Using subscription: #{subscription.inspect}")
           end
 
           Azure.configure do |azure|
@@ -35,8 +40,11 @@ class Chef
           end
         end
 
-        attr_accessor :driver
-        attr_accessor :subscription
+        attribute :driver
+        attribute :chef_server, kind_of: Hash
+        attribute :managed_entry_store, kind_of: Chef::Provisioning::ManagedEntryStore,
+                                  lazy_default: proc { Chef::Provisioning::ChefManagedEntryStore.new(chef_server) }
+        attribute :subscription
       end
     end
   end

--- a/lib/chef/provisioning/azure_driver/azure_resource.rb
+++ b/lib/chef/provisioning/azure_driver/azure_resource.rb
@@ -1,0 +1,43 @@
+require 'chef/resource/lwrp_base'
+require 'chef/provisioning/azure_driver/subscriptions'
+
+class Chef
+  module Provisioning
+    module AzureDriver
+      class AzureResource < Chef::Resource::LWRPBase
+        def initialize(*args)
+          super
+          @chef_environment = run_context.cheffish.current_environment
+          @chef_server = run_context.cheffish.current_chef_server
+          @driver = run_context.chef_provisioning.current_driver
+
+          config = run_context.chef_provisioning.config
+          scheme, account_id = driver.split(':', 2)
+
+          if account_id.nil? || account_id.empty?
+            subscription = Subscriptions.default_subscription(config)
+            if !subscription
+              raise "Driver #{driver_url} did not specify a subscription ID, and no default subscription was found.  Have you downloaded the Azure CLI and used `azure account download` and `azure account import` to set up Azure?  Alternately, you can set azure_subscriptions to [ { subscription_id: '...', management_credentials: ... }] in your Chef configuration."
+            end
+          end
+
+          config = Cheffish::MergedConfig.new({ azure_subscriptions: subscription }, config)
+          scheme, subscription_id = driver.split(':', 2)
+          @subscription = Subscriptions.get_subscription(config, subscription_id)
+          if !subscription
+            raise "Driver #{driver_url} has a subscription ID, but the system has no credentials configured for it!  If you have access to this subscription, you can use `azure account download` and `azure account import` in the Azure CLI to get the credentials, or set azure_subscriptions to [ { subscription_id: '...', management_credentials: ... }] in your Chef configuration."
+          end
+
+          Azure.configure do |azure|
+            azure.management_certificate = subscription[:management_certificate]
+            azure.subscription_id        = subscription[:subscription_id]
+            azure.management_endpoint    = subscription[:management_endpoint]
+          end
+        end
+
+        attr_accessor :driver
+        attr_accessor :subscription
+      end
+    end
+  end
+end

--- a/lib/chef/provisioning/azure_driver/resources.rb
+++ b/lib/chef/provisioning/azure_driver/resources.rb
@@ -1,7 +1,7 @@
-resources = %w(storage_account cloud_service)
+resources = %w(storage_account cloud_service sql_server)
 
 resources.each do |r|
-  Chef::Log.info "Loading resource: #{r}"
+  Chef::Log.debug("Loading resource: #{r}")
   require "chef/resource/azure_#{r}"
   require "chef/provider/azure_#{r}"
 end

--- a/lib/chef/provisioning/azure_driver/resources.rb
+++ b/lib/chef/provisioning/azure_driver/resources.rb
@@ -1,7 +1,7 @@
-resources = %w()
+resources = %w(storage_account cloud_service)
 
 resources.each do |r|
-  Chef::Log.debug "Loading #{r}"
+  Chef::Log.info "Loading resource: #{r}"
   require "chef/resource/azure_#{r}"
   require "chef/provider/azure_#{r}"
 end

--- a/lib/chef/provisioning/azure_driver/subscriptions.rb
+++ b/lib/chef/provisioning/azure_driver/subscriptions.rb
@@ -193,7 +193,7 @@ module Subscriptions
   def self.default_subscriptions(config)
     default_azure_profile = self.default_azure_profile(config)
     azure_publish_settings_file = Chef::Config.knife[:azure_publish_settings_file] if Chef::Config.knife
-    Chef::Log.info("No Chef::Config[:driver_options][:subscriptions] found, reading environment variables AZURE_SUBSCRIPTION_ID, AZURE_MANAGEMENT_CERTIFICATE, and AZURE_MANAGEMENT_ENDPOINT,#{azure_publish_settings_file ? " then #{azure_publish_settings_file}," : ""} and then reading #{default_azure_profile}")
+    Chef::Log.debug("No Chef::Config[:driver_options][:subscriptions] found, reading environment variables AZURE_SUBSCRIPTION_ID, AZURE_MANAGEMENT_CERTIFICATE, and AZURE_MANAGEMENT_ENDPOINT,#{azure_publish_settings_file ? " then #{azure_publish_settings_file}," : ""} and then reading #{default_azure_profile}")
     result = []
     result << {
       subscription_id:        ENV["AZURE_SUBSCRIPTION_ID"],

--- a/lib/chef/provisioning/azure_driver/version.rb
+++ b/lib/chef/provisioning/azure_driver/version.rb
@@ -2,7 +2,7 @@
 class Chef
 module Provisioning
 module AzureDriver
-  VERSION = '0.3.2'
+  VERSION = '0.3.2.1'
 end
 end
 end

--- a/lib/chef/provisioning/azure_driver/version.rb
+++ b/lib/chef/provisioning/azure_driver/version.rb
@@ -2,7 +2,7 @@
 class Chef
 module Provisioning
 module AzureDriver
-  VERSION = '0.3.2.1'
+  VERSION = '0.3.2'
 end
 end
 end

--- a/lib/chef/resource/azure_cloud_service.rb
+++ b/lib/chef/resource/azure_cloud_service.rb
@@ -1,0 +1,13 @@
+require 'chef/provisioning/azure_driver/azure_resource'
+
+class Chef
+  class Resource
+    class AzureCloudService < Chef::Provisioning::AzureDriver::AzureResource
+      resource_name 'azure_cloud_service'
+      actions :create, :destroy, :nothing
+      default_action :create
+      attribute :name, kind_of: String, name_attribute: true
+      attribute :options
+    end
+  end
+end

--- a/lib/chef/resource/azure_sql_server.rb
+++ b/lib/chef/resource/azure_sql_server.rb
@@ -1,0 +1,13 @@
+require 'chef/provisioning/azure_driver/azure_resource'
+
+class Chef
+  class Resource
+    class AzureSqlServer < Chef::Provisioning::AzureDriver::AzureResource
+      resource_name 'azure_sql_server'
+      actions :create, :destroy, :nothing
+      default_action :create
+      attribute :name, kind_of: String, name_attribute: true
+      attribute :options
+    end
+  end
+end

--- a/lib/chef/resource/azure_storage_account.rb
+++ b/lib/chef/resource/azure_storage_account.rb
@@ -1,0 +1,13 @@
+require 'chef/provisioning/azure_driver/azure_resource'
+
+class Chef
+  class Resource
+    class AzureStorageAccount < Chef::Provisioning::AzureDriver::AzureResource
+      resource_name 'azure_storage_account'
+      actions :create, :destroy, :nothing
+      default_action :create
+      attribute :name, kind_of: String, name_attribute: true
+      attribute :options
+    end
+  end
+end


### PR DESCRIPTION
This adds some support for people who want to create some basic non-Machine (PaaS) resources in Azure (Service Management old/aka the Old Portal) directly using chef-provisioning.

Specifically the following resources are available:

```ruby
azure_cloud_service
azure_storage_account
azure_sql_server
```

**No ManagedEntry is created in Chef server, the recipe will be the only document describing the objects that are created**

More will be added as the SDK allows.  Example usage is shown in an [example recipe](docs/resources/work_in_progress.rb) which has been used for testing.