### PR TITLE
Setting SSH username to vm_user other than specific machine/bootstrap_options property

### DIFF
--- a/lib/chef/provisioning/azure_driver/driver.rb
+++ b/lib/chef/provisioning/azure_driver/driver.rb
@@ -228,7 +228,8 @@ module AzureDriver
     end
 
     def create_ssh_transport(machine_spec, machine_options, vm)
-      username = machine_spec.location['ssh_username'] || default_ssh_username
+      bootstrap_options = machine_options[:bootstrap_options] || {}
+      username = bootstrap_options[:vm_user] || default_ssh_username
       tcp_endpoint = vm.tcp_endpoints.select { |tcp| tcp[:name] == 'SSH' }.first
       remote_host = tcp_endpoint[:vip]
 


### PR DESCRIPTION
RE #1 and #29 

Seems setting :ssh_username in either machine_options or bootstrap_options failed and the ssh username always defaulted to 'ubuntu'.

driver.rb now contains the SSH username is being extracted from the **vm_user** property in bootstrap_options 


Thanks,
